### PR TITLE
feat: add gzip compression support to HTTP handler middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.10.2
+
+- feat: support compression of http responses
+
 ## 1.10.1
 
 - chore: update dependencies

--- a/exthttp/exthttp.go
+++ b/exthttp/exthttp.go
@@ -9,6 +9,7 @@ package exthttp
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/klauspost/compress/gzhttp"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 	"github.com/rs/zerolog/log"
@@ -24,14 +25,14 @@ import (
 
 type Handler func(w http.ResponseWriter, r *http.Request, body []byte)
 
-// RegisterHttpHandler registers a handler for the given path. Also adds panic recovery and request logging around the handler.
+// RegisterHttpHandler registers a handler for the given path. Also adds panic recovery, gzip compression and request logging around the handler.
 func RegisterHttpHandler(path string, handler Handler) {
-	http.Handle(path, PanicRecovery(LogRequest(handler)))
+	http.Handle(path, PanicRecovery(gzhttp.GzipHandler(LogRequest(handler))))
 }
 
-// RegisterHttpHandlerWithLogLevel registers a handler for the given path. Also adds panic recovery and request logging with a given log level around the handler.
+// RegisterHttpHandlerWithLogLevel registers a handler for the given path. Also adds panic recovery, gzip compression and request logging with a given log level around the handler.
 func RegisterHttpHandlerWithLogLevel(path string, handler Handler, defaultLevel zerolog.Level) {
-	http.Handle(path, PanicRecovery(LogRequestWithDefaultLogLevel(handler, defaultLevel)))
+	http.Handle(path, PanicRecovery(gzhttp.GzipHandler(LogRequestWithDefaultLogLevel(handler, defaultLevel))))
 }
 
 // GetterAsHandler turns a getter function into a handler function. Typically used in combination with the RegisterHttpHandler function.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/elastic/go-sysinfo v1.15.4
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/klauspost/compress v1.18.4
 	github.com/madflojo/testcerts v1.5.0
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/rs/zerolog v1.34.0

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=


### PR DESCRIPTION
Reduces bandwidth for clients that send Accept-Encoding: gzip. Uses klauspost/compress/gzhttp which properly handles Content-Length, Flush/Hijack interfaces, and minimum body size thresholds.