### PR TITLE
docs: align CONTRIBUTING with canonical template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,29 @@
 # Contributing
 
-## Contributor License Agreement (CLA)
+## Prerequisites
 
-In order to accept your pull request, we need you to submit a CLA. You only need to do this once. If you are submitting a pull request for the first time, just submit a Pull Request and our CLA Bot will give you instructions on how to sign the CLA before merging your Pull Request.
+To work on this library locally, you need:
 
-All contributors must sign an [Individual Contributor License Agreement](https://github.com/steadybit/.github/blob/main/.github/cla/individual-cla.md).
+- [Go](https://go.dev/dl/) 1.25 or later
+- [GNU Make](https://www.gnu.org/software/make/)
 
-If contributing on behalf of your company, your company must sign a [Corporate Contributor License Agreement](https://github.com/steadybit/.github/blob/main/.github/cla/corporate-cla.md). If so, please contact us via office@steadybit.com.
+## Tasks
 
-If for any reason, your first contribution is in a PR created by other contributor, please just add a comment to the PR
-with the following text to agree our CLA: "I have read the CLA Document and I hereby sign the CLA".
+The `Makefile` in the project root contains commands to easily run common admin tasks.
+
+| Command        | Meaning                                                                     |
+|----------------|-----------------------------------------------------------------------------|
+| `$ make tidy`  | Format all code using `go fmt` and tidy the `go.mod` file.                  |
+| `$ make audit` | Run `go vet`, `staticcheck`, execute all tests and verify required modules. |
+
+## Releasing
+
+To make a new release, do the following:
+
+ 1. Update the `CHANGELOG.md`
+ 2. Commit and push the changelog changes.
+ 3. Set the tag `git tag -a vX.X.X -m vX.X.X`
+ 4. Push the tag.
 
 ## Generating New Test Certificates
 
@@ -22,3 +36,14 @@ openssl req -newkey rsa:2048 \
   -addext "subjectAltName = DNS:localhost" \
   -subj "/C=US/ST=California/L=Mountain View/O=Your Organization/OU=Your Unit/CN=localhost"
 ```
+
+## Contributor License Agreement (CLA)
+
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once. If you are submitting a pull request for the first time, just submit a Pull Request and our CLA Bot will give you instructions on how to sign the CLA before merging your Pull Request.
+
+All contributors must sign an [Individual Contributor License Agreement](https://github.com/steadybit/.github/blob/main/.github/cla/individual-cla.md).
+
+If contributing on behalf of your company, your company must sign a [Corporate Contributor License Agreement](https://github.com/steadybit/.github/blob/main/.github/cla/corporate-cla.md). If so, please contact us via office@steadybit.com.
+
+If for any reason, your first contribution is in a PR created by other contributor, please just add a comment to the PR
+with the following text to agree our CLA: "I have read the CLA Document and I hereby sign the CLA".


### PR DESCRIPTION
## Summary

Align CONTRIBUTING.md with the canonical library-variant template used across Steadybit extension repositories.

- Add an explicit **Prerequisites** section (Go, Make) so contributors know what they need to build locally.
- Add a **Tasks** table referencing the two Makefile targets that actually exist (`tidy`, `audit`).
- Add a **Releasing** section describing the tag-based release flow.
- Preserve the existing **Generating New Test Certificates** snippet as its own H2 section above the CLA.

No `Dockerfile`/`charts/` in this repo, so the container and Helm sections from the standard template are intentionally omitted.