### PR TITLE
fix: also exclude trivyignore-update commits from the CHANGELOG

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -31,7 +31,7 @@ on:
         description: Which component of the version to bump — major, minor, or patch (default)
       changelog_ignore_regex:
         type: string
-        default: '^chore(\(deps\))?: update helm chart version$|^docs:'
+        default: '^chore(\(deps\))?: update helm chart version$|^docs:|^chore: update (\.)?trivy|^chore\(trivy\):'
         description: |
           POSIX-extended regex (grep -vE) of commit subjects to exclude from the
           CHANGELOG.md entries. Default skips the auto-emitted helm chart bump


### PR DESCRIPTION
Trivyignore changes are CVE-scanner bookkeeping, not user-facing — they shouldn't show up as bullets in the release CHANGELOG. Extends the default `changelog_ignore_regex` to also drop:

- `chore: update trivyignore` (per user request)
- `chore: update trivy ignores`
- `chore: update .trivyignore.yml`
- `chore(trivy):` (going-forward scoped prefix)

Does not affect the safe-commit classifier — that one already treats these as safe via the file-only rule and the `chore(trivy):` prefix rule.

## Test plan

- [ ] After merge, force-dry-run any extension and confirm the trivy variants are absent from the bullet preview.