### PR TITLE
chore: default Slack channel to #sig-releases

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -38,8 +38,8 @@ on:
           (both legacy and current message) and docs-only commits.
       slack_channel:
         type: string
-        default: C02K21Y6H5Y
-        description: Slack channel ID to override in the webhook payload (default = #sig-development)
+        default: C0BA547TUKC
+        description: Slack channel ID to override in the webhook payload (default = #sig-releases)
     secrets:
       VERSION_BUMPER_SECRET:
         required: true


### PR DESCRIPTION
Routes auto-release and skip-unsafe notifications to #sig-releases (`C0BA547TUKC`) instead of #sig-development.

The channel remains overridable per caller via the `slack_channel` input.