### PR TITLE
fix: skip release when all commits in range match the ignore regex

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -33,9 +33,12 @@ on:
         type: string
         default: '^chore(\(deps\))?: update helm chart version$|^docs:|^chore: update (\.)?trivy|^chore\(trivy\):'
         description: |
-          POSIX-extended regex (grep -vE) of commit subjects to exclude from the
-          CHANGELOG.md entries. Default skips the auto-emitted helm chart bump
-          (both legacy and current message) and docs-only commits.
+          POSIX-extended regex of commit subjects to ignore. Matched commits
+          are treated as non-events — they neither trigger a release nor
+          appear in CHANGELOG.md. If every commit in the range matches, the
+          workflow silently exits with no-commits. Default skips the
+          auto-emitted helm chart bumps (legacy and current message), docs
+          commits, and trivy-ignore-list updates.
       slack_channel:
         type: string
         default: C0BA547TUKC
@@ -96,6 +99,7 @@ jobs:
         env:
           LATEST_TAG: ${{ steps.latest.outputs.tag }}
           FORCE_RELEASE: ${{ inputs.force_release }}
+          IGNORE_REGEX: ${{ inputs.changelog_ignore_regex }}
         run: |
           set -euo pipefail
 
@@ -108,12 +112,20 @@ jobs:
           fi
 
           count=0
+          ignored=0
           unsafe_sha=""
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
-            count=$((count + 1))
             author_email=$(git log -1 --format='%ae' "$sha")
             subject=$(git log -1 --format='%s' "$sha")
+
+            if [ -n "$IGNORE_REGEX" ] && echo "$subject" | grep -qE "$IGNORE_REGEX"; then
+              echo "  ignored                $sha  $subject"
+              ignored=$((ignored + 1))
+              continue
+            fi
+
+            count=$((count + 1))
             files=$(git diff-tree --no-commit-id --name-only -r "$sha")
 
             if [[ "$author_email" == *"dependabot[bot]"* ]]; then
@@ -144,6 +156,13 @@ jobs:
             echo "  UNSAFE                 $sha  $subject"
             [ -z "$unsafe_sha" ] && unsafe_sha="$sha"
           done <<< "$commits"
+
+          if [ "$count" -eq 0 ]; then
+            echo "outcome=no-commits" >> "$GITHUB_OUTPUT"
+            echo "commit_count=0" >> "$GITHUB_OUTPUT"
+            echo "No releasable commits since ${LATEST_TAG} (${ignored} ignored)"
+            exit 0
+          fi
 
           echo "commit_count=$count" >> "$GITHUB_OUTPUT"
           if [ "$FORCE_RELEASE" = "true" ] && [ -n "$unsafe_sha" ]; then


### PR DESCRIPTION
## Why

The just-completed force-release batch produced two noise-only releases (jmeter v1.0.36, jenkins v1.0.13). Each had exactly one commit in range — the auto-emitted `chore(deps): update helm chart version` from the prior release's CI — which was classified "safe" via the `chore(deps):` prefix rule and triggered another release with the `- Maintenance release` fallback.

## What

Applies the existing `changelog_ignore_regex` *before* commit classification. Matched commits are now logged as `ignored` and excluded from the safe/unsafe count. If every commit in the range matches the ignore regex, outcome becomes `no-commits` and the workflow silently exits — no release, no Slack, no CI churn.

The `changelog_ignore_regex` semantic is therefore now "ignored commits" — not just "omit from CHANGELOG". Description and behavior matrix updated accordingly.

## Behavior matrix examples

| Range | Before this PR | After this PR |
|---|---|---|
| only `chore(deps): update helm chart version` | released (fallback bullet) | no-commits, no release |
| only `docs: ...` | released | no-commits, no release |
| dependabot bump + chart-bump | released (1 bullet) | released (1 bullet) — unchanged |
| feat: + chart-bump | skip-unsafe | skip-unsafe — unchanged |

## Test plan

- [ ] Merge.
- [ ] Trigger workflow on extension-jmeter and extension-jenkins (both currently have only the post-release chart-bump in range). Expect: `No releasable commits since vX.Y.Z (1 ignored)` and no release/Slack.
- [ ] Trigger workflow on an extension with a fresh dependabot bump in range (will appear later this week). Expect: real release as before.