### PR TITLE
chore: drop dead chore(trivy) safe-classifier rule

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -136,10 +136,6 @@ jobs:
               echo "  safe (chore(deps))     $sha  $subject"
               continue
             fi
-            if [[ "$subject" == "chore(trivy):"* ]]; then
-              echo "  safe (chore(trivy))    $sha  $subject"
-              continue
-            fi
             if [[ "$subject" == "docs:"* ]]; then
               echo "  safe (docs)            $sha  $subject"
               continue


### PR DESCRIPTION
`chore(trivy):` is already caught by the ignore regex before the safe classifier ever runs, so the safe rule was dead code. Removing it to make the intent explicit: `chore(trivy):` is ignored, never triggers a release.

No behavior change with the default `changelog_ignore_regex`.