### PR TITLE
chore: also ignore test: commits in auto-release classification

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -31,7 +31,7 @@ on:
         description: Which component of the version to bump — major, minor, or patch (default)
       changelog_ignore_regex:
         type: string
-        default: '^chore(\(deps\))?: update helm chart version$|^docs:|^chore: update (\.)?trivy|^chore\(trivy\):'
+        default: '^chore(\(deps\))?: update helm chart version$|^docs:|^test:|^chore: update (\.)?trivy|^chore\(trivy\):'
         description: |
           POSIX-extended regex of commit subjects to ignore. Matched commits
           are treated as non-events — they neither trigger a release nor


### PR DESCRIPTION
Extends the default `changelog_ignore_regex` to also drop `test:`-prefixed commits. Same treatment as `docs:` and `chore(trivy):` — test changes don't ship runtime behavior, so they shouldn't trigger a release on their own or appear in the user-facing CHANGELOG.

No behavior change for ranges that already contain other unrelated commits.