### PR TITLE
feat: surface unsafe commits in the GH Actions step summary

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -113,7 +113,9 @@ jobs:
 
           count=0
           ignored=0
+          unsafe_count=0
           unsafe_sha=""
+          unsafe_rows=""
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
             author_email=$(git log -1 --format='%ae' "$sha")
@@ -151,6 +153,8 @@ jobs:
 
             echo "  UNSAFE                 $sha  $subject"
             [ -z "$unsafe_sha" ] && unsafe_sha="$sha"
+            unsafe_count=$((unsafe_count + 1))
+            unsafe_rows+="| \`${sha:0:7}\` | ${subject//|/\\|} |"$'\n'
           done <<< "$commits"
 
           if [ "$count" -eq 0 ]; then
@@ -161,12 +165,35 @@ jobs:
           fi
 
           echo "commit_count=$count" >> "$GITHUB_OUTPUT"
+          safe_count=$((count - unsafe_count))
           if [ "$FORCE_RELEASE" = "true" ] && [ -n "$unsafe_sha" ]; then
             echo "FORCE_RELEASE: overriding ${count} commit(s) (first unsafe ${unsafe_sha}) to outcome=safe"
             echo "outcome=safe" >> "$GITHUB_OUTPUT"
+            {
+              echo "## :warning: Force-release — bypassing ${unsafe_count} unsafe commit(s)"
+              echo ""
+              echo "Latest tag: \`${LATEST_TAG}\`. \`force_release=true\` is set, so these commits are released anyway:"
+              echo ""
+              echo "| Commit | Subject |"
+              echo "|---|---|"
+              printf '%s' "$unsafe_rows"
+              echo ""
+              echo "Also in range: ${safe_count} safe, ${ignored} ignored."
+            } >> "$GITHUB_STEP_SUMMARY"
           elif [ -n "$unsafe_sha" ]; then
             echo "outcome=skip-unsafe" >> "$GITHUB_OUTPUT"
             echo "unsafe_sha=${unsafe_sha:0:7}" >> "$GITHUB_OUTPUT"
+            {
+              echo "## :no_entry_sign: Release skipped — ${unsafe_count} unsafe commit(s) since \`${LATEST_TAG}\`"
+              echo ""
+              echo "These commits block the auto-release. A manual release is needed to move past them, or re-run with \`force_release=true\` to bypass:"
+              echo ""
+              echo "| Commit | Subject |"
+              echo "|---|---|"
+              printf '%s' "$unsafe_rows"
+              echo ""
+              echo "Also in range: ${safe_count} safe, ${ignored} ignored."
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "outcome=safe" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
Per Daniel's suggestion: writes the commits that block (or are bypassed by) the auto-release into the run's step summary, so they show up on the Actions run page without diving into the log.

Two summary variants emitted from the `Evaluate commits` step:

- :no_entry_sign: *Release skipped — N unsafe commit(s)* with a markdown table of those commits, plus how many safe/ignored ones were also in range.
- :warning: *Force-release — bypassing N unsafe commit(s)* with the same table when `force_release=true` is set.

Pipe-characters in commit subjects are escaped so they don't break the markdown table.

## Test plan

- [ ] Trigger workflow on extension-scaffold (has the `feat: drop "Monday"...` unsafe commit) with `dry_run=true`. Verify the run page shows a `:no_entry_sign:` summary with that commit in the table.
- [ ] Trigger same with `force_release=true, dry_run=true`. Verify the summary now reads `:warning: Force-release — bypassing` with the same commit listed.