### PR TITLE
feat: classify build: commits as safe in auto-release

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -138,6 +138,10 @@ jobs:
               echo "  safe (chore(deps))     $sha  $subject"
               continue
             fi
+            if [[ "$subject" =~ ^build(\([^)]*\))?: ]]; then
+              echo "  safe (build)           $sha  $subject"
+              continue
+            fi
             if [[ "$subject" == "docs:"* ]]; then
               echo "  safe (docs)            $sha  $subject"
               continue


### PR DESCRIPTION
Adds a safe-classifier rule matching `^build(\([^)]*\))?:` so commits like `build:`, `build(deps):`, and `build(docker):` are treated equivalently to `chore(deps):` — released and listed in the CHANGELOG.

Dependabot already used `build(deps):` for some ecosystems (e.g. goreleaser, docker, github-actions), and was caught by the dependabot-author rule. This new rule generalizes it to any `build:` commit regardless of author.