### PR TITLE
ci: skip heavy build on chart-version-bump commits

### DIFF
--- a/.github/workflows/reusable-extension-ci.yml
+++ b/.github/workflows/reusable-extension-ci.yml
@@ -115,8 +115,27 @@ on:
         description: Identity provider to use to be able to push to gcp artifact registry
 
 jobs:
+  detect-changes:
+    name: Detect chart-only changes
+    runs-on: ubuntu-latest
+    outputs:
+      # 'other-than-charts' is 'false' when no file outside charts/ changed.
+      # Restricted to pushes to main so tags and pull requests always get the full pipeline.
+      charts_only: ${{ steps.changes.outputs.other-than-charts == 'false' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c # NOSONAR githubactions:S7637 - dorny/paths-filter v4.0.0, established org convention
+        id: changes
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            other-than-charts:
+              - '!charts/**'
+
   audit:
     name: Audit
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.charts_only != 'true'
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 60
     env:
@@ -405,7 +424,9 @@ jobs:
   test-helm-charts:
     name: "Test Helm Charts"
     runs-on: ubuntu-latest
-    needs: [audit]
+    needs: [detect-changes, audit]
+    # Runs when audit succeeds and, on a chart-only push to main, when audit was skipped.
+    if: ${{ !cancelled() && needs.audit.result != 'failure' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

After every extension release, the `bump-chart-version` job pushes a `chore(deps): update helm chart version` commit to `main`. That commit only edits `charts/steadybit-extension-*/Chart.yaml` (via `make chart-bump-version`), but because `ci.yml` has no path/job filtering, the push re-runs the **entire** pipeline — `audit`, `build-images` (Docker multi-arch), `build-packages` (GoReleaser), Snyk, SonarCloud — even though no extension code changed. The only thing that actually needs to run is the helm chart (re)publish.

## Change

Add a `detect-changes` gate job using **`dorny/paths-filter`** (the convention already used in `agent` and `platform`) that marks a push to `main` touching only `charts/**` as chart-only:

- **`audit`** is skipped on a chart-only push. Because `build-images`, `build-packages`, `snyk-monitor`, `bump-chart-version`, `trigger-test-environment-updates` and `check-go-package` all `needs` it (directly or transitively) with no `if: always()`, they cascade-skip automatically.
- **`test-helm-charts`** is relaxed to `if: !cancelled() && needs.audit.result != 'failure'` so it still runs when `audit` was *skipped* (chart-only) — but not when it *failed*.
- **`release-helm-chart`** is unchanged; it still runs via `needs: [test-helm-charts]` and publishes the chart.

Net effect on a chart-bump commit: only `detect-changes` → `test-helm-charts` → `release-helm-chart` run.

Tags and pull requests are unaffected — `charts_only` is gated on `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so they always get the full pipeline.

## Scope

This is the shared reusable workflow (`@main`), so it takes effect for **all** extensions on their next run.

## Verification

- [ ] YAML parses; all 10 jobs intact (`detect-changes` added).
- [ ] After merge, trigger one extension release and confirm on the follow-up `chore(deps): update helm chart version` push: `audit`/`build-images`/`build-packages`/`trigger-test-environment-updates` show **Skipped**, while `test-helm-charts` and `release-helm-chart` **run** and the chart publishes as before.
- [ ] A normal code push to `main` still runs the full pipeline.
