### PR TITLE
fix: avoid bash regex parse error in build: safe classifier

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -138,10 +138,12 @@ jobs:
               echo "  safe (chore(deps))     $sha  $subject"
               continue
             fi
-            if [[ "$subject" =~ ^build(\([^)]*\))?: ]]; then
-              echo "  safe (build)           $sha  $subject"
-              continue
-            fi
+            case "$subject" in
+              "build:"* | "build("*"):"*)
+                echo "  safe (build)           $sha  $subject"
+                continue
+                ;;
+            esac
             if [[ "$subject" == "docs:"* ]]; then
               echo "  safe (docs)            $sha  $subject"
               continue


### PR DESCRIPTION
The `[[ "$subject" =~ ^build(\([^)]*\))?: ]]` regex form fails at bash parse time with `syntax error in conditional expression: unexpected token ')'`. Bash's `[[ ]]` parser doesn't tolerate the nested-paren literal regex.

The bug only surfaced on extension ranges where commits reached the build classifier (e.g. extension-aws, extension-azure on this Monday's cron). Ranges where earlier rules `continue`d first never parsed the broken line, which masked the bug at rollout time.

Switches to a case statement matching both `build:` and `build(scope):` — unambiguous, POSIX-portable, no regex parsing concerns.

## Test plan

- [ ] Merge.
- [ ] Re-trigger `Auto Patch Release` on extension-aws and extension-azure. Expect successful completion (likely skip-unsafe due to other commits, but no bash parse error).