### PR TITLE
fix: drop trailing exit-test that tripped set -e in evaluate step

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -206,8 +206,6 @@ jobs:
             echo "**Totals:** ${safe_count} safe · ${unsafe_count} blocking · ${ignored} ignored"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          [ "$outcome" = "no-commits" ] && exit 0
-
       - name: Compute next version and changelog bullets
         if: steps.evaluate.outputs.outcome == 'safe'
         id: next


### PR DESCRIPTION
Hot-fix on #142: the closing `[ "$outcome" = "no-commits" ] && exit 0` line was meant as a guard against running later steps in the no-commits case, but with `set -e` enabled the failing `[ ]` test (everything except no-commits) propagates the non-zero exit and the step fails.

It's also redundant — every later step is already gated on `steps.evaluate.outputs.outcome == 'safe'`, so the no-commits / skip-unsafe paths naturally skip them.

Caught immediately on the first scaffold dry-run after #142 merged.