### PR TITLE
chore: ignore bare 'build:' commits in auto-release

### DIFF
--- a/.github/workflows/reusable-auto-patch-release.yml
+++ b/.github/workflows/reusable-auto-patch-release.yml
@@ -31,7 +31,7 @@ on:
         description: Which component of the version to bump — major, minor, or patch (default)
       changelog_ignore_regex:
         type: string
-        default: '^chore(\(deps\))?: update helm chart version$|^docs:|^test:|^chore: update (\.)?trivy|^chore\(trivy\):'
+        default: '^chore(\(deps\))?: update helm chart version$|^docs:|^test:|^build: |^chore: update (\.)?trivy|^chore\(trivy\):'
         description: |
           POSIX-extended regex of commit subjects to ignore. Matched commits
           are treated as non-events — they neither trigger a release nor
@@ -138,7 +138,7 @@ jobs:
               count=$((count + 1))
             else
               case "$subject" in
-                "build:"* | "build("*"):"*)
+                "build("*"):"*)
                   assessment="safe"
                   echo "  safe (build)           $sha  $subject"
                   count=$((count + 1))


### PR DESCRIPTION
Bare `build:` commits (no scope) are build-system tweaks like CI config renames and Makefile edits — they don't change runtime behavior and shouldn't trigger releases on their own or appear in the user-facing CHANGELOG. The previous rollout PR (`build: rename workflow_dispatch input labels for the GH UI`) leaked into 30 extensions' latest CHANGELOG sections, which is what surfaced this gap.

`build(scope):` commits — notably `build(deps):` which dependabot uses for github-actions / docker / goreleaser ecosystems — remain in the safe classifier and continue to trigger releases.

A companion CHANGELOG cleanup sweep across the 30 affected extensions is being opened in parallel.