### PR TITLE
feat: add CmdState.Wait/ExitCode to read a command's exit code race-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (next)
 
+- feat: add `CmdState.Wait()` and `CmdState.ExitCode()` to `extcmd` so extensions can read a command's exit code without racing the goroutine that reaps the process
+
 ## 1.10.5
 
 - feat: add `extruntime.AdjustOOMScoreAdj()` to protect extensions from the Linux OOM killer

--- a/extcmd/cmdstate.go
+++ b/extcmd/cmdstate.go
@@ -9,14 +9,35 @@ import (
 	"github.com/steadybit/extension-kit/extutil"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 )
 
 type CmdState struct {
 	Id                  string
 	Cmd                 *exec.Cmd
+	exitCode            atomic.Int32
 	mu                  *sync.Mutex
 	out                 *bytes.Buffer
 	lastPartialLineRead string
+}
+
+// Wait blocks until the command exits and records its exit code. It must be called
+// exactly once — typically as `go cmdState.Wait()` right after the command is started.
+// Wait is the sole reader of Cmd.ProcessState, so concurrent callers must obtain the
+// exit code via ExitCode rather than reading Cmd.ProcessState directly; doing the
+// latter races this method. The error returned by exec.Cmd.Wait is passed through for
+// logging.
+func (cs *CmdState) Wait() error {
+	err := cs.Cmd.Wait()
+	cs.exitCode.Store(int32(cs.Cmd.ProcessState.ExitCode()))
+	return err
+}
+
+// ExitCode returns the command's exit code, or -1 while it is still running or if it
+// was terminated by a signal, matching os.ProcessState.ExitCode(). It is safe to call
+// concurrently with the Wait goroutine.
+func (cs *CmdState) ExitCode() int {
+	return int(cs.exitCode.Load())
 }
 
 func (cs *CmdState) Write(p []byte) (n int, err error) {

--- a/extcmd/cmdstate_test.go
+++ b/extcmd/cmdstate_test.go
@@ -10,6 +10,9 @@ package extcmd
 import (
 	"bytes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os/exec"
+	"runtime"
 	"sync"
 	"testing"
 )
@@ -33,4 +36,49 @@ func TestCmdStateReadsFullLines(t *testing.T) {
 	assert.Equal(t, 0, len(is.GetLines(false)))
 
 	assert.Equal(t, []string{"Second line"}, is.GetLines(true))
+}
+
+func TestCmdStateExitCode(t *testing.T) {
+	cs := NewCmdState(exec.Command("sh", "-c", "exit 7"))
+	defer RemoveCmdState(cs.Id)
+
+	// -1 while the command has not yet exited, matching os.ProcessState.ExitCode().
+	assert.Equal(t, -1, cs.ExitCode())
+
+	require.NoError(t, cs.Cmd.Start())
+	err := cs.Wait()
+
+	require.Error(t, err) // a non-zero exit makes exec.Cmd.Wait return an *ExitError
+	assert.Equal(t, 7, cs.ExitCode())
+}
+
+func TestCmdStateExitCodeSuccess(t *testing.T) {
+	cs := NewCmdState(exec.Command("sh", "-c", "exit 0"))
+	defer RemoveCmdState(cs.Id)
+
+	require.NoError(t, cs.Cmd.Start())
+	require.NoError(t, cs.Wait())
+	assert.Equal(t, 0, cs.ExitCode())
+}
+
+func TestCmdStateExitCodeIsConcurrencySafe(t *testing.T) {
+	cs := NewCmdState(exec.Command("sh", "-c", "exit 0"))
+	defer RemoveCmdState(cs.Id)
+	require.NoError(t, cs.Cmd.Start())
+
+	// Readers (as the status/stop handlers do) must not race the Wait goroutine
+	// (caught by `go test -race`).
+	var wg sync.WaitGroup
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for cs.ExitCode() == -1 {
+				runtime.Gosched()
+			}
+		}()
+	}
+	require.NoError(t, cs.Wait())
+	wg.Wait()
+	assert.Equal(t, 0, cs.ExitCode())
 }

--- a/extcmd/extcmd.go
+++ b/extcmd/extcmd.go
@@ -26,6 +26,7 @@ func NewCmdState(cmd *exec.Cmd) *CmdState {
 	state := new(CmdState)
 	state.Id = uuid.NewString()
 	state.Cmd = cmd
+	state.exitCode.Store(-1)
 	state.out = new(bytes.Buffer)
 	state.mu = new(sync.Mutex)
 


### PR DESCRIPTION
## Why

Several extensions run a command non-blocking and reap it in a goroutine:

```go
go func() { _ = cmd.Wait() }()   // cmd.Wait() writes cmd.ProcessState
```

then read the result from their Status/Stop handlers:

```go
exitCode := cmdState.Cmd.ProcessState.ExitCode()   // concurrent read → data race
```

`cmd.Wait()` sets `cmd.ProcessState`, so this is a data race on that field (flagged by `go test -race`, and able to yield torn reads). `extcmd.CmdState` already owns the `*exec.Cmd`, the output buffer and its mutex, but exposed `Cmd` directly and synchronized only the output buffer — so every consumer hand-rolled the same racy pattern. The identical race currently exists in **extension-gatling, extension-jmeter, extension-k6 and extension-postman**.

## What

Give `CmdState` ownership of the process result:

- `CmdState.Wait() error` — reaps the process (`cmd.Wait()`) and records the exit code into an internal `atomic.Int32`. It is the **sole** reader of `cmd.ProcessState`. Returns the `exec.Cmd.Wait` error for logging.
- `CmdState.ExitCode() int` — returns the recorded exit code, or `-1` while the process is still running (or was signal-terminated), matching `os.ProcessState.ExitCode()`. Safe to call concurrently with the `Wait` goroutine.

Consumers replace `go func(){ cmd.Wait() }()` with `go cmdState.Wait()` and read `cmdState.ExitCode()` instead of `cmdState.Cmd.ProcessState`.

`Cmd` stays exported (callers still need `Start()`, `Process`, env, etc.); the `Wait()` doc steers callers to `ExitCode()` rather than reading `ProcessState` directly.

## Follow-up

Once this is released, the four extensions above will be migrated to `go cmdState.Wait()` + `cmdState.ExitCode()` (extension-gatling#138 will be repointed to this API).

## Verification

`go build ./...`, `go vet ./extcmd/`, and `go test -race ./extcmd/` all pass. New tests cover non-zero exit, zero exit, and concurrent readers racing the `Wait` goroutine under `-race`.
