### PR TITLE
feat: add extheartbeat shared heartbeat watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (next)
 
+- feat: add `extheartbeat` — a concurrency-safe heartbeat watchdog (`Monitor`/`Notify`) shared by the action- and preflight-kit SDKs, which previously each carried their own identical copy
+
 ## 1.10.6
 
 - feat: add `CmdState.Wait()` and `CmdState.ExitCode()` to `extcmd` so extensions can read a command's exit code without racing the goroutine that reaps the process

--- a/extheartbeat/heartbeat.go
+++ b/extheartbeat/heartbeat.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+// Package extheartbeat provides a small watchdog that signals when heartbeats stop
+// arriving within a timeout. It is used by the action- and preflight-kit SDKs to detect a
+// stalled controlling platform; both previously carried their own identical copy.
+package extheartbeat
+
+import (
+	"github.com/rs/zerolog/log"
+	"sync"
+	"time"
+)
+
+type Monitor struct {
+	mu     sync.Mutex
+	pulse  chan time.Time
+	closed bool
+}
+
+// Notify starts a monitor: it forwards a single value on ch (then closes ch) if no
+// heartbeat is recorded within timeout, and closes ch when the monitor is stopped.
+func Notify(ch chan<- time.Time, interval, timeout time.Duration) *Monitor {
+	pulse := make(chan time.Time, 10)
+
+	go func(pulse <-chan time.Time, signal chan<- time.Time) {
+		last := time.Now()
+		log.Debug().
+			Dur("interval", interval).
+			Dur("timeout", timeout).
+			Time("last", last).
+			Msg("starting heartbeat")
+		for {
+			select {
+			case ts, ok := <-pulse:
+				if ok {
+					log.Trace().
+						Dur("interval", interval).
+						Dur("timeout", timeout).
+						Time("current", ts).
+						Time("last", last).
+						Msg("received heartbeat")
+					last = ts
+				} else {
+					log.Debug().
+						Dur("interval", interval).
+						Dur("timeout", timeout).
+						Time("last", last).
+						Msg("heartbeat stopped")
+					close(signal)
+					return
+				}
+			case <-time.After(interval):
+				log.Debug().
+					Dur("interval", interval).
+					Dur("timeout", timeout).
+					Time("last", last).
+					Msg("missing timeout")
+				if time.Since(last) > timeout {
+					log.Warn().
+						Dur("interval", interval).
+						Dur("timeout", timeout).
+						Time("last", last).
+						Msg("no heartbeat received")
+					signal <- time.Now()
+					close(signal)
+					return
+				} else {
+					log.Trace().Msg("missed heartbeat")
+				}
+			}
+		}
+	}(pulse, ch)
+
+	return &Monitor{
+		pulse: pulse,
+	}
+}
+
+func (h *Monitor) RecordHeartbeat() {
+	log.Trace().Msg("received heartbeat")
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	// Non-blocking send: once Stop has closed the channel we must not send (that panics),
+	// and if the buffer is full the reader only needs to see recent activity — so dropping
+	// a beat is fine and must never block the caller (an HTTP status handler goroutine).
+	select {
+	case h.pulse <- time.Now():
+	default:
+	}
+}
+
+// Stop is idempotent: concurrent or repeated Stop calls (e.g. the HTTP stop handler and
+// the heartbeat-timeout goroutine both stopping the same execution) close the channel once.
+func (h *Monitor) Stop() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return
+	}
+	log.Debug().Msg("closing heartbeat channel")
+	h.closed = true
+	close(h.pulse)
+}

--- a/extheartbeat/heartbeat_test.go
+++ b/extheartbeat/heartbeat_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2026 Steadybit GmbH
+
+package extheartbeat
+
+import (
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestHeartbeat_should_timeout(t *testing.T) {
+	ch := make(chan time.Time)
+	hb := Notify(ch, 300*time.Millisecond, 150*time.Millisecond)
+	defer hb.Stop()
+
+	time.Sleep(150 * time.Millisecond)
+	hb.RecordHeartbeat()
+	time.Sleep(350 * time.Millisecond)
+
+	select {
+	case <-ch:
+	default:
+		t.Fatal("callback should have been called")
+	}
+}
+
+func TestHeartbeat_should_not_timeout(t *testing.T) {
+	ch := make(chan time.Time)
+	hb := Notify(ch, 300*time.Millisecond, 150*time.Millisecond)
+	defer hb.Stop()
+
+	hb.RecordHeartbeat()
+	time.Sleep(150 * time.Millisecond)
+	hb.RecordHeartbeat()
+	time.Sleep(150 * time.Millisecond)
+	hb.RecordHeartbeat()
+	time.Sleep(150 * time.Millisecond)
+
+	select {
+	case <-ch:
+		t.Fatal("callback should not have been called")
+	default:
+	}
+}
+
+func TestHeartbeat_timeout_should_close_channel(t *testing.T) {
+	i := atomic.Uint32{}
+	w := make(chan interface{})
+	ch := make(chan time.Time)
+	hb := Notify(ch, 10*time.Millisecond, 20*time.Millisecond)
+	defer hb.Stop()
+
+	go func() {
+		for {
+			select {
+			case <-w:
+				return
+			case v := <-ch:
+				if (v != time.Time{}) && (i.Add(1) > 1) {
+					t.Error("callback called multiple times")
+				}
+			}
+		}
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	w <- nil
+	assert.Equal(t, i.Load(), uint32(1))
+}
+
+// TestMonitor_concurrent_stop_and_record hammers RecordHeartbeat with concurrent and
+// repeated Stop calls: it must never panic (double close / send on closed channel), and a
+// RecordHeartbeat after Stop must be a no-op. Run under -race.
+func TestMonitor_concurrent_stop_and_record(t *testing.T) {
+	ch := make(chan time.Time, 1)
+	hb := Notify(ch, time.Hour, time.Hour)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); hb.RecordHeartbeat() }()
+	}
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); hb.Stop() }()
+	}
+	wg.Wait()
+
+	// After Stop, further heartbeats are dropped rather than panicking.
+	hb.RecordHeartbeat()
+	hb.Stop()
+}


### PR DESCRIPTION
## Why

`action_kit_sdk` and `preflight_kit_sdk` each carried a byte-identical `heartbeat` package (a channel-based watchdog: `Monitor` + `Notify` + `RecordHeartbeat`/`Stop`). That duplication recently caused the **same concurrency bug to be fixed twice** — [action-kit#457](https://github.com/steadybit/action-kit/pull/457) and [preflight-kit#52](https://github.com/steadybit/preflight-kit/pull/52) both had to make `Stop` idempotent and `RecordHeartbeat` a non-blocking, closed-safe send. That's the textbook signal to deduplicate.

## What

Add `extheartbeat` here — the (already-fixed) concurrency-safe watchdog — so both SDKs can share one implementation and it can't diverge again. `extension-kit` is already a dependency of both SDKs, so this adds **no new module coupling**.

The API is unchanged from the copies both SDKs already use: `Notify(ch, interval, timeout) *Monitor`, `(*Monitor).RecordHeartbeat()`, `(*Monitor).Stop()`.

## Follow-up (after this is tagged)

Two SDK PRs will bump to the new `extension-kit`, switch their internals to `extheartbeat`, and **delete** their local `heartbeat` packages (clean removal — no external consumers). The action-kit PR will also fold in the same re-Start monitor-leak fix that preflight-kit#52 got.

## Verification

`go build`, `go vet`, `go test -race ./extheartbeat/` pass — includes the concurrency test (concurrent RecordHeartbeat vs repeated Stop) plus the original timeout tests.
