### PR TITLE
fix: stop extutil converters panicking on malformed config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (next)
 
+- fix: `extutil.ToString`/`ToBool`/`ToKeyValue`/`ToStringArray` no longer panic on malformed (agent-supplied) config values — they return the zero value (or an error, for `ToKeyValue`) on a type mismatch, matching the other `To*` converters
+
 ## 1.10.7
 
 - feat: add `extheartbeat` — a concurrency-safe heartbeat watchdog (`Monitor`/`Notify`) shared by the action- and preflight-kit SDKs, which previously each carried their own identical copy

--- a/extutil/extutil.go
+++ b/extutil/extutil.go
@@ -113,21 +113,23 @@ func ToInt32(val interface{}) int32 {
 }
 
 func ToString(val interface{}) string {
-	if val == nil {
-		return ""
+	if s, ok := val.(string); ok {
+		return s
 	}
-	return val.(string)
+	// Non-string (or nil) config values yield "" rather than panicking, matching the
+	// zero-value-on-mismatch behavior of the other To* converters.
+	return ""
 }
 
 func ToBool(val interface{}) bool {
-	if val == nil || val == "" {
-		return false
+	if s, ok := val.(string); ok {
+		return s == "true"
 	}
-	// parse bool string
-	if val, ok := val.(string); ok {
-		return val == "true"
+	if b, ok := val.(bool); ok {
+		return b
 	}
-	return val.(bool)
+	// nil or any other type is not truthy — return false instead of panicking.
+	return false
 }
 
 func ToKeyValue(config map[string]interface{}, configName string) (map[string]string, error) {
@@ -142,7 +144,12 @@ func ToKeyValue(config map[string]interface{}, configName string) (map[string]st
 		if !ok {
 			return nil, fmt.Errorf("failed to interpret config value for %s as a key/value array", configName)
 		}
-		result[entry["key"].(string)] = entry["value"].(string)
+		key, keyOk := entry["key"].(string)
+		value, valueOk := entry["value"].(string)
+		if !keyOk || !valueOk {
+			return nil, fmt.Errorf("failed to interpret config value for %s as a key/value array", configName)
+		}
+		result[key] = value
 	}
 
 	return result, nil
@@ -192,13 +199,17 @@ func MustHaveValue[T any, K comparable](m map[K]T, key K) T {
 }
 
 func ToStringArray(s interface{}) []string {
-	if s == nil {
+	arr, ok := s.([]interface{})
+	if !ok {
+		// nil or any non-slice value yields nil rather than panicking.
 		return nil
 	}
 
-	tokens := make([]string, len(s.([]interface{})))
-	for i, v := range s.([]interface{}) {
-		tokens[i] = v.(string)
+	tokens := make([]string, 0, len(arr))
+	for _, v := range arr {
+		if str, ok := v.(string); ok {
+			tokens = append(tokens, str)
+		}
 	}
 	return tokens
 }

--- a/extutil/extutil_test.go
+++ b/extutil/extutil_test.go
@@ -154,6 +154,8 @@ func TestToString(t *testing.T) {
 	}{
 		{name: "string 'anything' should return 'anything'", args: args{val: "anything"}, want: "anything"},
 		{name: "nil should return ''", args: args{val: nil}, want: ""},
+		{name: "non-string number should return '' (not panic)", args: args{val: float64(42)}, want: ""},
+		{name: "non-string bool should return '' (not panic)", args: args{val: true}, want: ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -178,6 +180,7 @@ func TestToBool(t *testing.T) {
 		{name: "string 'anything' should return false", args: args{val: "anything"}, want: false},
 		{name: "string '' should return false", args: args{val: ""}, want: false},
 		{name: "nil should return false", args: args{val: nil}, want: false},
+		{name: "non-string non-bool number should return false (not panic)", args: args{val: float64(1)}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -199,6 +202,31 @@ func TestToKeyValue(t *testing.T) {
 func TestToToStringArray(t *testing.T) {
 	value := ToStringArray([]any{"key", "testKey", "value", "testValue"})
 	require.Equal(t, []string([]string{"key", "testKey", "value", "testValue"}), value)
+}
+
+func TestToKeyValue_malformed_returns_error_not_panic(t *testing.T) {
+	// value that isn't a key/value array
+	_, err := ToKeyValue(map[string]interface{}{"headers": "not-an-array"}, "headers")
+	require.Error(t, err)
+
+	// entry with a non-string value must return an error, not panic
+	_, err = ToKeyValue(map[string]interface{}{"headers": []any{
+		map[string]any{"key": "k", "value": 42},
+	}}, "headers")
+	require.Error(t, err)
+
+	// entry missing the value key must return an error, not panic
+	_, err = ToKeyValue(map[string]interface{}{"headers": []any{
+		map[string]any{"key": "k"},
+	}}, "headers")
+	require.Error(t, err)
+}
+
+func TestToStringArray_malformed_returns_nil_or_skips_not_panic(t *testing.T) {
+	assert.Nil(t, ToStringArray(nil))
+	assert.Nil(t, ToStringArray("not-a-slice"))
+	// non-string elements are skipped rather than panicking
+	assert.Equal(t, []string{"a", "b"}, ToStringArray([]any{"a", 42, "b", true}))
 }
 
 func TestMaskString(t *testing.T) {


### PR DESCRIPTION
## Problem

Four `extutil` converters used bare type assertions and **panic** when handed a config value of an unexpected type:

- `ToString` — `val.(string)` panics on any non-nil non-string (e.g. a JSON number/bool)
- `ToBool` — `val.(bool)` panics on a non-string non-bool
- `ToKeyValue` — `entry["key"].(string)` / `["value"].(string)` panic on a missing or non-string key/value
- `ToStringArray` — `s.([]interface{})` and `v.(string)` panic on a non-slice or non-string element

Config values come from agent-supplied JSON (`map[string]interface{}`), and these helpers are called **pervasively across ~33 extensions** — including in discovery loops and background workers that aren't wrapped by `exthttp.PanicRecovery`. A malformed value there crashes the whole extension process. (Sibling converters `ToInt`/`ToInt32`/`ToInt64`/`ToUInt` already avoid this — they return `0` on a type mismatch.)

## Fix

Use comma-ok assertions and return the zero value on a type mismatch, matching the `ToInt*` convention:
- `ToString` → `""`, `ToBool` → `false`, `ToStringArray` → `nil` (non-slice) / skips non-string elements
- `ToKeyValue` keeps its existing `error` contract — a non-string/missing key or value now returns the descriptive error instead of panicking

String-case behavior is unchanged (`ToBool` still treats only `"true"` as true, etc.). Adds tests for the malformed-input paths.

## Scope

This is the first of the extension-kit audit fixes. Still to come as separate PRs: `exthttp.LogRequestWithDefaultLogLevel` missing `return` after a body-read error, and the `exthealth`/`extsignals` shutdown-path data races.

## Verification

`go build`, `go vet`, `go test ./extutil/` pass.
