### PR TITLE
fix: stop processing a request whose body can't be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (next)
 
+- fix: reject a request with a 400 and stop processing when its body can't be read, instead of falling through and running the handler with a nil body after the response was already written (`exthttp` request-logging middleware)
+
 - fix: `extutil.ToString`/`ToBool`/`ToKeyValue`/`ToStringArray` no longer panic on malformed (agent-supplied) config values — they return the zero value (or an error, for `ToKeyValue`) on a type mismatch, matching the other `To*` converters
 
 ## 1.10.7

--- a/exthttp/exthttp.go
+++ b/exthttp/exthttp.go
@@ -86,6 +86,7 @@ func LogRequestWithDefaultLogLevel(next Handler, defaultLevel zerolog.Level) htt
 		if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
 			if bytes, err := io.ReadAll(r.Body); err != nil {
 				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
 			} else {
 				reqBody = bytes
 			}

--- a/exthttp/exthttp_test.go
+++ b/exthttp/exthttp_test.go
@@ -6,6 +6,7 @@ package exthttp
 
 import (
 	"compress/gzip"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,9 +15,29 @@ import (
 	"time"
 
 	"github.com/klauspost/compress/gzhttp"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, errors.New("boom") }
+func (errReadCloser) Close() error             { return nil }
+
+func TestLogRequestWithDefaultLogLevel_bodyReadError_rejects_and_skips_handler(t *testing.T) {
+	nextCalled := false
+	h := LogRequestWithDefaultLogLevel(func(w http.ResponseWriter, r *http.Request, body []byte) {
+		nextCalled = true
+	}, zerolog.InfoLevel)
+
+	req := httptest.NewRequest(http.MethodPost, "/x", errReadCloser{})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.False(t, nextCalled, "the handler must not run when the request body cannot be read")
+}
 
 func TestRequestTimeoutHeaderAware(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

`LogRequestWithDefaultLogLevel` (the `exthttp` request-logging middleware wrapping every handler) reads the request body and, on an `io.ReadAll` error, wrote a `400` but did **not** return:

```go
if bytes, err := io.ReadAll(r.Body); err != nil {
    http.Error(w, err.Error(), http.StatusBadRequest)   // 400 written...
} else {
    reqBody = bytes
}
// ...falls through...
next(w, r, reqBody)   // ...then runs the handler with reqBody == nil
```

So on a truncated/aborted/oversized body it (a) ran the wrapped handler on a request it had already rejected, and (b) let the handler write a second header/body over the committed `400` → `superfluous WriteHeader` and a corrupted response. This affects every handler across all extensions.

## Fix

`return` after `http.Error`, so a body-read failure rejects the request cleanly and the handler doesn't run. Adds a regression test (body that errors on read → `400`, wrapped handler not invoked).

## Verification

`go build`, `go vet`, `go test ./exthttp/` pass.
