### PR TITLE
fix: data race and panic on the extension shutdown path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - fix: reject a request with a 400 and stop processing when its body can't be read, instead of falling through and running the handler with a nil body after the response was already written (`exthttp` request-logging middleware)
 
 - fix: `extutil.ToString`/`ToBool`/`ToKeyValue`/`ToStringArray` no longer panic on malformed (agent-supplied) config values — they return the zero value (or an error, for `ToKeyValue`) on a type mismatch, matching the other `To*` converters
+- fix: `exthealth` no longer has a data race on the probes HTTP server pointer — it is assigned before the serving goroutine starts, so `StopProbes` and the shutdown signal handler can't race the assignment or read a nil server
+- fix: `extsignals` recovers panics per signal handler (one misbehaving handler can no longer crash the dispatch goroutine and abort the remaining ordered shutdown handlers) and no longer panics on a non-`syscall.Signal`
 
 ## 1.10.7
 

--- a/exthealth/health.go
+++ b/exthealth/health.go
@@ -86,25 +86,25 @@ func StartProbes(port int) {
 	serverMux := http.NewServeMux()
 	addLivenessProbe(serverMux.Handle)
 	addReadinessProbe(serverMux.Handle)
+	// Assign the package-level server before starting the goroutine so StopProbes and the
+	// StopProbesHTTP signal handler never race the assignment (nor read a nil server).
+	server = &http.Server{Addr: fmt.Sprintf(":%d", healthPort), Handler: serverMux}
+
+	extsignals.AddSignalHandler(extsignals.SignalHandler{
+		Handler: func(signal os.Signal) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			log.Info().Msg("Stopping Probes HTTP Server")
+			if err := server.Shutdown(ctx); err != nil {
+				log.Warn().Msgf("Probes HTTP Server Shutdown Failed: %+v", err)
+			}
+		},
+		Order: extsignals.OrderStopProbesHttp,
+		Name:  "StopProbesHTTP",
+	})
+
 	go func() {
 		log.Info().Msgf("Starting probes server on port %d, ready: %t", healthPort, atomic.LoadInt32(&isReady) == 1)
-		server = &http.Server{Addr: fmt.Sprintf(":%d", healthPort), Handler: serverMux}
-
-		extsignals.AddSignalHandler(extsignals.SignalHandler{
-			Handler: func(signal os.Signal) {
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer func() {
-					cancel()
-				}()
-				log.Info().Msg("Stopping Probes HTTP Server")
-				if err := server.Shutdown(ctx); err != nil {
-					log.Warn().Msgf("Probes HTTP Server Shutdown Failed: %+v", err)
-				}
-			},
-			Order: extsignals.OrderStopProbesHttp,
-			Name:  "StopProbesHTTP",
-		})
-
 		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Fatal().Err(err).Msgf("Failed to start probes server")
 		}

--- a/extsignals/signalhandler.go
+++ b/extsignals/signalhandler.go
@@ -54,6 +54,18 @@ func RemoveSignalHandlersByName(names ...string) {
 	}
 }
 
+// callSignalHandler invokes a signal handler, recovering from a panic so one misbehaving
+// handler can't crash the dispatch goroutine and abort the remaining (ordered) handlers —
+// which include the HTTP-server shutdown and readiness handlers.
+func callSignalHandler(handler SignalHandler, s os.Signal) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error().Str("handler", handler.Name).Msgf("signal handler panicked: %v", r)
+		}
+	}()
+	handler.Handler(s)
+}
+
 func createSignalChannel(context context.Context) chan os.Signal {
 	signalChannel := make(chan os.Signal, 1)
 	Notify(signalChannel)
@@ -70,10 +82,13 @@ func createSignalChannel(context context.Context) chan os.Signal {
 					return true
 				})
 				sort.Sort(ByOrder(handlerList))
-				signalName := GetSignalName(s.(syscall.Signal))
+				signalName := s.String()
+				if sysSig, ok := s.(syscall.Signal); ok {
+					signalName = GetSignalName(sysSig)
+				}
 				for _, handler := range handlerList {
 					log.Debug().Str("signal", signalName).Str("handler", handler.Name).Int("order", handler.Order).Msg("received signal - call handler")
-					handler.Handler(s)
+					callSignalHandler(handler, s)
 				}
 			}
 		}

--- a/extsignals/signalhandler_test.go
+++ b/extsignals/signalhandler_test.go
@@ -56,6 +56,32 @@ func TestSignalHandlers(t *testing.T) {
 	require.Equal(t, handlerList.Load(), "Handler2Handler1")
 }
 
+func TestSignalHandler_panicking_handler_does_not_abort_others(t *testing.T) {
+	survivorRun := atomic.Bool{}
+
+	ClearSignalHandlers()
+	defer ClearSignalHandlers()
+	ActivateSignalHandlers()
+	RemoveSignalHandlersByName("Termination")
+	AddSignalHandler(SignalHandler{
+		Handler: func(os.Signal) { panic("boom") },
+		Order:   10,
+		Name:    "Panicker",
+	})
+	AddSignalHandler(SignalHandler{
+		Handler: func(os.Signal) { survivorRun.Store(true) },
+		Order:   20, // ordered after the panicking handler
+		Name:    "Survivor",
+	})
+
+	err := Kill(os.Getpid())
+	require.NoError(t, err)
+
+	<-time.After(500 * time.Millisecond)
+
+	require.True(t, survivorRun.Load(), "a panicking handler must not prevent later handlers from running")
+}
+
 func TestRemoveSignalHandlersByName(t *testing.T) {
 	handler1Run := atomic.Bool{}
 	handler2Run := atomic.Bool{}


### PR DESCRIPTION
## Problem

Two shutdown-path defects in the shared SDK (from the kit audit):

1. **`exthealth` data race (MAJOR).** `StartProbes` assigned the package-level `server` **inside** the serving goroutine, while `StopProbes` and the `StopProbesHTTP` signal handler **read** it. That's a data race on the `*http.Server` pointer, and a `StopProbes` that runs before the goroutine schedules its write sees a `nil` server (so the probes server is never stopped).
2. **`extsignals` panic / crash (MAJOR).** The signal-dispatch loop called each `handler.Handler(s)` with no recover, so a panic in **any** registered handler killed the dispatch goroutine — aborting all remaining *ordered* shutdown handlers (HTTP-server shutdown, readiness-false, …) and crashing the process. It also did a bare `s.(syscall.Signal)` assertion that panics on a non-`syscall.Signal`.

## Fix

1. Create `server` (and register the `StopProbesHTTP` handler) **synchronously in `StartProbes` before** spawning the goroutine, which now only runs `ListenAndServe`. `server` is written once, before any reader can run — no race, no nil read.
2. Wrap each handler call in a per-handler `recover` (`callSignalHandler`), so one bad handler can't abort the rest, and guard the signal-name assertion with comma-ok + an `s.String()` fallback.

Adds a regression test: a panicking handler no longer prevents a later ordered handler from running (would crash the test binary before the fix).

## Scope / left as-is

- The `log.Fatal` on `ListenAndServe` bind failure is pre-existing and orthogonal (a probe server that can't bind is a fatal startup condition) — not folded in.
- The `Termination` handler's `signal.(syscall.Signal)` is safe (guarded by its `case syscall.SIGINT/SIGTERM`) and untouched.

## Verification

`go build`, `go vet`, `go test -race ./exthealth/ ./extsignals/` all pass.
