### PR TITLE
fix: include image tag in cve scan artifact names

### DIFF
--- a/.github/workflows/reusable-cve-scan.yml
+++ b/.github/workflows/reusable-cve-scan.yml
@@ -115,9 +115,10 @@ jobs:
         env:
           INPUT_SCAN_TYPE: ${{ inputs.scan_type }}
           INPUT_SCAN_REF: ${{ inputs.scan-ref }}
+          INPUT_IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
           if [ "$INPUT_SCAN_TYPE" = "image" ]; then
-            SUFFIX="${{ steps.image.outputs.name }}"
+            SUFFIX="${{ steps.image.outputs.name }}${INPUT_IMAGE_TAG:+-$INPUT_IMAGE_TAG}"
             SUFFIX="${SUFFIX//\//-}"
           else
             SUFFIX="$INPUT_SCAN_REF"


### PR DESCRIPTION
Scanning the same image with multiple tags in one workflow run (e.g. `main` and `java-25` in steadybit/docker-images) produces identical artifact names, so the second `upload-artifact` fails with a 409 conflict.

This appends the `image_tag` input to the artifact name suffix for image scans, e.g. `trivy-results-steadybit-zulu-openjdk-main`.

Note: artifact names of existing callers gain a `-<tag>` suffix; anything downloading these artifacts by exact name needs updating.