### PR TITLE
feat(exthttp): centralize extension index ETag via Revision/BumpRevision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## (next)
 
-- feat: `exthttp.Revision()`/`BumpRevision()` and `exthttp.RegisterIndexHandler` centralize the extension index ETag. The revision is seeded with a startup nonce and bumped whenever a kit registers/clears a describable element, so the agent's index-response cache invalidates on registration changes without relying on a process restart. Extensions can replace the hand-rolled `startedAt` + `IfNoneMatchHandler` boilerplate with `exthttp.RegisterIndexHandler("/", getExtensionList)`.
+- feat: `exthttp.Revision()`/`BumpRevision()` and `exthttp.RegisterRevisionedHandler` centralize the extension index ETag. The revision is seeded with a startup nonce and bumped whenever a kit registers/clears a describable element, so the agent's index-response cache invalidates on registration changes without relying on a process restart. Extensions can replace the hand-rolled `startedAt` + `IfNoneMatchHandler` boilerplate with `exthttp.RegisterRevisionedHandler("/", getExtensionList)`.
 
 ## 1.10.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (next)
 
+- feat: `exthttp.Revision()`/`BumpRevision()` and `exthttp.RegisterIndexHandler` centralize the extension index ETag. The revision is seeded with a startup nonce and bumped whenever a kit registers/clears a describable element, so the agent's index-response cache invalidates on registration changes without relying on a process restart. Extensions can replace the hand-rolled `startedAt` + `IfNoneMatchHandler` boilerplate with `exthttp.RegisterIndexHandler("/", getExtensionList)`.
+
 ## 1.10.8
 
 - fix: reject a request with a 400 and stop processing when its body can't be read, instead of falling through and running the handler with a nil body after the response was already written (`exthttp` request-logging middleware)

--- a/exthttp/revision.go
+++ b/exthttp/revision.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package exthttp
+
+import (
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+// The revision is the ETag for the combined extension index endpoint ("/"). It changes on process
+// start (seeded with a nanosecond startup nonce) and whenever a kit SDK registers or clears a
+// describable element (via BumpRevision). This lets the agent cache the index response and skip the
+// per-element describe calls on a matching If-None-Match, without relying on a process restart to
+// invalidate the cache.
+//
+// The value is kept as a plain, unquoted string so it round-trips through the agent's
+// If-None-Match/ETag handling byte-for-byte, matching the historical startedAt behavior.
+var (
+	revisionSeed    = strconv.FormatInt(time.Now().UnixNano(), 36)
+	revisionCounter atomic.Uint64
+)
+
+// Revision returns the current index revision string. It changes on process start and whenever any
+// kit registers/unregisters a describable element, so it is a safe ETag for the combined index.
+func Revision() string {
+	return revisionSeed + "-" + strconv.FormatUint(revisionCounter.Load(), 10)
+}
+
+// BumpRevision advances the index revision. Kit SDKs call this from their Register*/Clear* functions
+// whenever the set of registered describable elements changes.
+func BumpRevision() {
+	revisionCounter.Add(1)
+}
+
+// RegisterIndexHandler registers the combined extension index at path, ETag-tagged with the current
+// Revision(). Extensions should use this instead of hand-rolling IfNoneMatchHandler with a
+// process-start timestamp.
+func RegisterIndexHandler[T any](path string, getter func() T) {
+	RegisterHttpHandler(path, IfNoneMatchHandler(Revision, GetterAsHandler(getter)))
+}

--- a/exthttp/revision.go
+++ b/exthttp/revision.go
@@ -35,9 +35,10 @@ func BumpRevision() {
 	revisionCounter.Add(1)
 }
 
-// RegisterIndexHandler registers the combined extension index at path, ETag-tagged with the current
-// Revision(). Extensions should use this instead of hand-rolling IfNoneMatchHandler with a
-// process-start timestamp.
-func RegisterIndexHandler[T any](path string, getter func() T) {
+// RegisterRevisionedHandler registers a handler that serves the getter's result at path, tagging the
+// response with the current Revision() as its ETag so it supports conditional GET (a matching
+// If-None-Match yields 304). Use this instead of hand-rolling IfNoneMatchHandler with a
+// process-start timestamp, e.g. for the combined extension index.
+func RegisterRevisionedHandler[T any](path string, getter func() T) {
 	RegisterHttpHandler(path, IfNoneMatchHandler(Revision, GetterAsHandler(getter)))
 }

--- a/exthttp/revision_test.go
+++ b/exthttp/revision_test.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package exthttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBumpRevisionChangesRevision(t *testing.T) {
+	before := Revision()
+	BumpRevision()
+	after := Revision()
+
+	assert.NotEqual(t, before, after, "revision must change after BumpRevision")
+}
+
+func TestRevisionStableWithoutBump(t *testing.T) {
+	assert.Equal(t, Revision(), Revision(), "revision must be stable without a bump")
+}
+
+func TestRegisterIndexHandlerEmitsEtagAndServes304(t *testing.T) {
+	handler := IfNoneMatchHandler(Revision, GetterAsHandler(func() map[string]string {
+		return map[string]string{"hello": "world"}
+	}))
+
+	rec := httptest.NewRecorder()
+	handler(rec, httptest.NewRequest(http.MethodGet, "/", nil), nil)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	etag := rec.Header().Get("ETag")
+	require.NotEmpty(t, etag, "ETag header must be set on a 200 response")
+	assert.Equal(t, Revision(), etag)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("If-None-Match", etag)
+	rec = httptest.NewRecorder()
+	handler(rec, req, nil)
+
+	assert.Equal(t, http.StatusNotModified, rec.Code, "matching If-None-Match must return 304")
+}


### PR DESCRIPTION
## What

Adds `exthttp.Revision()`, `exthttp.BumpRevision()`, and `exthttp.RegisterRevisionedHandler` so the extension index ETag becomes an SDK guarantee instead of per-extension `main.go` boilerplate.

- `Revision()` — current revision string. Seeded at package init with a startup nonce (`time.Now().UnixNano()`, base36) so it differs across restarts, plus an atomic counter.
- `BumpRevision()` — advances the revision; kit SDKs call this from their `Register*`/`Clear*` functions.
- `RegisterRevisionedHandler[T](path, getter)` — registers a handler that serves the getter's result tagged with `Revision()` as its ETag (conditional GET → 304 on matching `If-None-Match`), replacing the hand-rolled `startedAt` + `IfNoneMatchHandler` wiring.

## Why

Previously each extension froze a `startedAt` timestamp at process start and wrapped `/` with `IfNoneMatchHandler`. That made index caching copy-pasted boilerplate (an extension that forgot the wrapper silently lost caching) and boot-scoped rather than registration-scoped. The revision reflects the registered description set, so the agent's index-response cache invalidates on registration changes without needing a restart.

## Compatibility

The ETag value stays an **unquoted** string, byte-identical to the historical `startedAt`, so it round-trips through the agent's `If-None-Match`/`ETag` handling unchanged — no agent-side coordination required. `IfNoneMatchHandler` is unchanged and stays public for back-compat.

## Follow-ups

The `*-kit` SDKs (action/discovery/advice/preflight) will bump this dependency and add `BumpRevision()` calls once this is tagged; extensions then swap their boilerplate to `RegisterRevisionedHandler`.