### PR TITLE
chore: remove unused use_kvm input and KVM code path

### DIFF
--- a/.github/workflows/reusable-extension-ci.yml
+++ b/.github/workflows/reusable-extension-ci.yml
@@ -19,10 +19,6 @@ on:
         type: string
         required: false
         default: ubuntu-latest
-      use_kvm:
-        type: boolean
-        required: false
-        default: false
       run_make_prepare_audit:
         type: boolean
         required: false
@@ -155,17 +151,6 @@ jobs:
         with:
           go-version: ${{ inputs.go_version }}
 
-      - name: Enable KVM group perms
-        if: ${{ inputs.use_kvm }}
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-          sudo apt-get update
-          sudo apt-get install -y libvirt-clients libvirt-daemon-system libvirt-daemon virtinst bridge-utils qemu-user-static qemu-system-x86
-          sudo usermod -a -G kvm,libvirt $USER
-          sudo -u $USER env "PATH=$PATH" virsh domcapabilities --virttype="kvm"
-
       - name: Prepare audit
         if: ${{ inputs.run_make_prepare_audit }}
         run: |
@@ -174,13 +159,7 @@ jobs:
       - name: Audit
         run: |
           go mod download
-          echo ${{ inputs.use_kvm }}
-          if [ "${{ inputs.use_kvm }}" != 'true' ]; then
-            make audit
-          else
-            echo 'exec in a new sell for the group change to take effect'
-            sudo -u $USER env "PATH=$PATH" make audit
-          fi
+          make audit
 
       - name: "[release] Snyk test"
         if: ${{ startsWith(github.ref, 'refs/tags/') && env.snyk_available == 'true' }}


### PR DESCRIPTION
## What
Remove the `use_kvm` input and its associated code from `reusable-extension-ci.yml`:
- the `use_kvm` workflow input
- the `Enable KVM group perms` step (installed `qemu-system-x86` + libvirt and configured KVM)
- the `use_kvm` branch in the `Audit` step (now just `go mod download && make audit`)

## Why
It's dead code:
- The input defaulted to `false`, so the KVM step (`if: inputs.use_kvm`) and the `else` branch never executed.
- **No consumer passes it** — an org-wide code search finds `use_kvm` only inside this file.
- `extension-host` (the last user) removed it in `54d8024 build: don't use kvm for e2e tests`, switching its e2e tests to the Docker-driver minikube.

## Safety
Removing the input is safe because no caller sets it (passing an undefined input would be the only breakage, and none do). Behaviour is unchanged for every current consumer — they all took the non-KVM path already.