### PR TITLE
build: install snyk via npm so the audit job works on ARM runners

### DIFF
--- a/.github/workflows/reusable-extension-ci.yml
+++ b/.github/workflows/reusable-extension-ci.yml
@@ -168,8 +168,11 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/') && env.snyk_available == 'true' }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        # Version pinned for reproducibility (this runs at release time, so avoid a surprise major bump).
+        # Note: no --ignore-scripts here (unlike the semver install below) because snyk's postinstall
+        # bootstraps its CLI binary.
         run: |
-          npm install -g snyk
+          npm install -g snyk@1.1306.1
           snyk test --org=${{ vars.SNYK_ORG_ID }} --severity-threshold=high --project-name=${{ github.repository }} --target-reference=${{ github.ref_name }}
 
       - name: Download e2e coverage files

--- a/.github/workflows/reusable-extension-ci.yml
+++ b/.github/workflows/reusable-extension-ci.yml
@@ -162,13 +162,15 @@ jobs:
           make audit
 
       - name: "[release] Snyk test"
+        # Install the CLI via npm rather than the snyk/actions/golang Docker action: that action's image
+        # (snyk/snyk:golang) is amd64-only and is pre-pulled at job init, which breaks this job on ARM runners.
+        # npm resolves the correct native binary per architecture, so this works on both amd64 and arm64.
         if: ${{ startsWith(github.ref, 'refs/tags/') && env.snyk_available == 'true' }}
-        uses: snyk/actions/golang@master  # NOSONAR githubactions:S7637 - verified action creator
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --org=${{ vars.SNYK_ORG_ID }} --severity-threshold=high --project-name=${{ github.repository }} --target-reference=${{ github.ref_name }}
-          command: test
+        run: |
+          npm install -g snyk
+          snyk test --org=${{ vars.SNYK_ORG_ID }} --severity-threshold=high --project-name=${{ github.repository }} --target-reference=${{ github.ref_name }}
 
       - name: Download e2e coverage files
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## What
Replace the Docker-based `snyk/actions/golang@master` step in the `audit` job with an npm install of the Snyk CLI + `snyk test`.

```diff
- uses: snyk/actions/golang@master
- with: { args: --org=… --severity-threshold=high …, command: test }
+ run: |
+   npm install -g snyk
+   snyk test --org=… --severity-threshold=high --project-name=… --target-reference=…
```

## Why
The `audit` job is the only job that honours the `runs_on` input, so it's the one we'd want to run on ARM. But `snyk/actions/golang`'s image (`snyk/snyk:golang`) is **amd64-only**, and GitHub **pre-pulls Docker-action images at job init regardless of the step's `if:`** — so the job fails at init on an ARM runner with `no matching manifest for linux/arm64/v8`.

`npm install -g snyk` resolves the correct native binary per architecture (Node/npm are preinstalled on GitHub-hosted runners), so it works on **both amd64 and arm64**. The setup action (`snyk/actions/setup`) is not an option — it hardcodes the amd64 `snyk-linux` binary with no arch detection.

## Impact
- **amd64 (all current consumers): behaviour unchanged** — same `snyk test` invocation, just installed via npm instead of a container.
- Makes the reusable workflow **ARM-capable** (prerequisite for moving extensions like `extension-host` to the cheaper ARM custom runner).
- The step only runs on release tags (`if: startsWith(github.ref, 'refs/tags/')`), so it first exercises on the next tagged release.